### PR TITLE
Clean up logging

### DIFF
--- a/src/cmd/forwarder/main.go
+++ b/src/cmd/forwarder/main.go
@@ -11,6 +11,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"time"
+
 	"github.com/cloudfoundry/bosh-system-metrics-forwarder/pkg/auth"
 	"github.com/cloudfoundry/bosh-system-metrics-forwarder/pkg/definitions"
 	"github.com/cloudfoundry/bosh-system-metrics-forwarder/pkg/egress"
@@ -21,7 +23,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"time"
 )
 
 func main() {
@@ -63,8 +64,9 @@ func main() {
 	messages := make(chan *loggregator_v2.Envelope, 1024)
 
 	// server setup (ingress)
+	logger := log.New(os.Stderr, "", log.LstdFlags)
 	serverClient, serverConnClose := setupConnToMetricsServer(*metricsServerAddr, *metricsCN, *metricsCA)
-	i := ingress.New(serverClient, mapper.New(*envelopeIpTag), messages, authClient, *subscriptionID)
+	i := ingress.New(serverClient, mapper.New(*envelopeIpTag), messages, authClient, *subscriptionID, logger)
 
 	// metron setup (egress)
 	metronClient, metronConnClose := setupConnToMetron(*metronPort, *metronCA, *metronCert, *metronKey)


### PR DESCRIPTION
We reconnect to the server every 45 seconds by using a timeout. The
timeout is intentional so not logging the timeout error to keep logs
clean.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

